### PR TITLE
Update API docs for v20210308

### DIFF
--- a/models/listing.20210308.yaml
+++ b/models/listing.20210308.yaml
@@ -3,14 +3,14 @@ type: object
 description: |-
   Representation of a listing on a provider.
 
-  **Latest version: 20191126**
+  **Latest version: 20210308**
 x-examples:
   Example:
     id: 121.1005001.1234567
     property_id: 12345
     provider: HOMEAWAY
     name: Flat 123
-    nickname: Relaxing villa by the sea
+    public_name: Relaxing villa by the sea
     picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
     address:
       apartment: 37a
@@ -47,7 +47,7 @@ properties:
     description: Where this listing is listed.
   name:
     type: string
-  nickname:
+  public_name:
     type:
       - string
       - 'null'
@@ -58,7 +58,7 @@ properties:
     $ref: ./address.yaml
   timezone:
     type: string
-    description: "Numeric offset of the listing's timezone from UTC"
+    description: Numeric offset of the listing's timezone from UTC
     example: '-0930'
     minLength: 5
     maxLength: 5
@@ -101,7 +101,7 @@ properties:
     description: The provider URL to the listing.
   user_id:
     type: string
-    description: "The provider's identifier for the user who owns the listing."
+    description: The provider's identifier for the user who owns the listing.
   room_type:
     type: string
     enum:

--- a/models/property.20210308.yaml
+++ b/models/property.20210308.yaml
@@ -3,12 +3,13 @@ type: object
 description: |-
   Representation of a property.
 
-  **Latest version: 20191121**
+  **Latest version: 20210308**
 x-examples:
   Example:
     id: '123456'
     name: Room with a view of a tree
     picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
+    currency: EUR
     address:
       apartment: 37a
       street: Senefelderplatz
@@ -65,6 +66,10 @@ properties:
   listed:
     type: boolean
     description: Whether the property is listed on provider websites
+  currency:
+    type: string
+    minLength: 3
+    maxLength: 3
 required:
   - id
   - name
@@ -73,3 +78,4 @@ required:
   - timezone
   - features
   - listed
+  - currency

--- a/paths/calendar/openapi.yaml
+++ b/paths/calendar/openapi.yaml
@@ -47,6 +47,7 @@ paths:
                     data:
                       - uuid: 48b62e97-91bf-4c6f-af49-6dc71c16a16a
                         guest_uuid: 32a46404-1fca-49b4-966e-c88a76886135
+                        listing_id: '12345'
                         provider: AIRBNB
                         reservation_code: ABSDHEUSHM
                         status: ACCEPTED
@@ -79,7 +80,27 @@ paths:
                       current_page: 1
                       total_pages: 1
       operationId: get-reservations
-      description: "Given listings and (optionally) check-in dates, returns a filtered list of reservations.\n\n### URL parameters\n\n- `listings[]`: Array of listing IDs to get reservations for - use as: `?listings[]=123&listings[]=456`. These are the IDs that are available in HomeAway / Airbnb, and you can also get them from the `GET /listings` endpoint.\n- `start_date`: Optional, find reservations with check-in dates after this day. Y-m-d format, defaults to today.\n- `end_date`: Optional, find reservations with check-in dates before this day. Y-m-d format, defaults to `start_date` + 14 days.\n\n\n### Allowed Includes\n\n- `guest`\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/calendar/reservations?listings[]=123456&listings[]=654321&start_date=2019-08-31&end_date=2019-09-30'\n```"
+      description: |-
+        Given listings and (optionally) check-in dates, returns a filtered list of reservations.
+
+        ### URL parameters
+
+        - `listings[]`: Array of listing IDs to get reservations for - use as: `?listings[]=123&listings[]=456`. These are the IDs that are available in HomeAway / Airbnb, and you can also get them from the `GET /listings` endpoint.
+        - `start_date`: Optional, find reservations with check-in dates after this day. Y-m-d format, defaults to today.
+        - `end_date`: Optional, find reservations with check-in dates before this day. Y-m-d format, defaults to `start_date` + 14 days.
+
+
+        ### Allowed Includes
+
+        - `guest`
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/calendar/reservations?listings[]=123456&listings[]=654321&start_date=2019-08-31&end_date=2019-09-30'
+        ```
       parameters:
         - schema:
             type: string
@@ -103,6 +124,22 @@ paths:
           description: The ID of the listing to retrieve the calendar for
           schema:
             type: string
+        - in: unknown
+        - schema:
+            type: string
+            format: date
+            example: '2020-12-25'
+          in: query
+          name: start_date
+          description: Date to pull the calendar from.
+        - schema:
+            type: string
+            format: date
+            example: '2020-12-25'
+          in: query
+          name: end_date
+          description: Date to pull the calendar to.
+        - $ref: ../properties/openapi.yaml#/components/parameters/provider-required
       responses:
         '200':
           description: OK
@@ -150,7 +187,27 @@ paths:
                         rel: calendar
                         version: '20190611'
       operationId: get-calendar
-      description: "Given a listing ID and (optionally) dates, returns the Pricing and Availability for the listing in calendar format.\n\n### URL parameters\n\n- `start_date`: Optional, start date for the calendar range in `Y-m-d` format, defaults to today.\n- `end_date`: Optional, end date for the calendar range in `Y-m-d` format, defaults to `start_date` + 14 days.\n\n\n### Allowed Includes\n\nNone.\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/calendar/123456&start_date=2019-08-31&end_date=2019-09-30'\n```\n"
+      description: |
+        Given a listing ID and (optionally) dates, returns the Pricing and Availability for the listing in calendar format.
+
+        ### URL parameters
+
+        - `provider`: The provider of the listing - either `airbnb`, `booking`, or `homeaway`.
+        - `start_date`: Optional, start date for the calendar range in `Y-m-d` format, defaults to today.
+        - `end_date`: Optional, end date for the calendar range in `Y-m-d` format, defaults to `start_date` + 14 days.
+
+
+        ### Allowed Includes
+
+        None.
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/calendar/123456?provider=airbnb&start_date=2019-08-31&end_date=2019-09-30'
+        ```
       security:
         - OAuth2:
             - 'read:calendar'
@@ -173,7 +230,43 @@ paths:
                     reason_phrase: 'No markup price found for listing 12345 was found, refusing to set price for a property without a markup'
         '':
           description: 'The calendar update has been accepted, and placed onto a queue to be dealt with asynchronously.'
-      description: "Update a Listing's pricing, availability, and minimum stay for the given dates. This request is handled asynchronously, and therefore the pricing on your listing may take a few seconds to update after receiving a response.\n\nIt's possible to send a Property ID instead of a Listing ID, if you also send the query parameter `type=property`. There are two important distinctions to be made when sending a Property ID:\n\n1. Pricing for all listings within that Property will be updated, not just for one.\n2. A Markup will be applied to each price. This markup must be pre-configured in the Smartbnb website first. Wihout this pre-configuration, this endpoint will fail with a `409 Conflict` response.\n\n**Please note that updating availability for HomeAway is, at this time, not functional, and therefore for listings on HomeAway the `available` boolean value in the payload is ignored. You may update pricing for HomeAway as normal, though.**\n\n### Example\n\n```bash\ncurl -X PUT \\\n  https://api.smartbnb.io/calendar/123456 \\\n  -H 'Authorization: Bearer <TOKEN>' \\\n  -H 'content-type: application/vnd.smartbnb.20191231+json' \\\n  --data '[\n    {\n      \"date\": \"2020-01-11\",\n      \"available\": true,\n      \"min_stay\": 3,\n      \"price\": {\n        \"amount\": 7700,\n      }\n    },\n    {\n      \"date\": \"2020-01-12\",\n      \"available\": true,\n      \"price\": {\n        \"amount\": 7800,\n      }\n    }\n]'\n```"
+      description: |-
+        Update a Listing's pricing, availability, and minimum stay for the given dates. This request is handled asynchronously, and therefore the pricing on your listing may take a few seconds to update after receiving a response.
+
+        It's possible to send a Property ID instead of a Listing ID, if you also send the query parameter `type=property`. There are two important distinctions to be made when sending a Property ID:
+
+        1. Pricing for all listings within that Property will be updated, not just for one.
+        2. A Markup will be applied to each price. This markup must be pre-configured in the Smartbnb website first. Wihout this pre-configuration, this endpoint will fail with a `409 Conflict` response.
+
+        When sending a **Listing ID**, the Provider must be added in the query string: `provider=airbnb`, `provider=booking`, or `provider=homeaway`. This is not required when sending a Property ID.
+
+        **Please note that updating availability for HomeAway is, at this time, not functional, and therefore for listings on HomeAway the `available` boolean value in the payload is ignored. You may update pricing for HomeAway as normal, though.**
+
+        ### Example
+
+        ```bash
+        curl -X PUT \
+          https://api.smartbnb.io/calendar/123456?provider=airbnb \
+          -H 'Authorization: Bearer <TOKEN>' \
+          -H 'content-type: application/vnd.smartbnb.20191231+json' \
+          --data '[
+            {
+              "date": "2020-01-11",
+              "available": true,
+              "min_stay": 3,
+              "price": {
+                "amount": 7700,
+              }
+            },
+            {
+              "date": "2020-01-12",
+              "available": true,
+              "price": {
+                "amount": 7800,
+              }
+            }
+        ]'
+        ```
       tags:
         - calendar
         - write
@@ -255,6 +348,7 @@ paths:
           in: query
           name: type
           description: Set this to `property` to set pricing for all listings in a property. Caveats apply.
+        - $ref: ../properties/openapi.yaml#/components/parameters/provider-optional
     parameters:
       - schema:
           type: string

--- a/paths/properties/openapi.yaml
+++ b/paths/properties/openapi.yaml
@@ -13,7 +13,7 @@ info:
     email: hello@smartbnb.io
 servers:
   - url: 'https://api.smartbnb.io'
-    description: 'Property & listing endpoints'
+    description: Property & listing endpoints
 paths:
   /listings:
     get:
@@ -32,7 +32,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: ../../models/listing.20191126.yaml
+                      $ref: ../../models/listing.20210308.yaml
                   _pagination:
                     $ref: ../../models/pagination.yaml
                 required:
@@ -43,9 +43,11 @@ paths:
                   value:
                     data:
                       - id: '12345'
+                        property_id: 123
                         provider: AIRBNB
                         name: Relaxing Villa near the sea
                         picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
+                        currency: EUR
                         address:
                           apartment: 37a
                           street: Senefelderplatz
@@ -105,7 +107,20 @@ paths:
                       current_page: 2
                       total_pages: 51
       operationId: get-listings
-      description: "Get all listings that are on channels connected to your smartbnb account.\n\n### Allowed Includes\n\n(none)\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/listings'\n```"
+      description: |-
+        Get all listings that are on channels connected to your smartbnb account.
+
+        ### Allowed Includes
+
+        (none)
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/listings'
+        ```
       security:
         - OAuth2:
             - 'read:calendar'
@@ -131,7 +146,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: ../../models/listing.20191126.yaml
+                    $ref: ../../models/listing.20210308.yaml
                 required:
                   - data
               examples:
@@ -139,9 +154,11 @@ paths:
                   value:
                     data:
                       id: '12345'
+                      property_id: 123
                       provider: AIRBNB
                       name: Relaxing Villa near the sea
                       picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
+                      currency: EUR
                       address:
                         apartment: 37a
                         street: Senefelderplatz
@@ -167,10 +184,27 @@ paths:
                         rel: listing
                         version: '20190902'
       operationId: get-listing-by-id
-      description: "Get a listing from one of your channels by its listing ID\n\n### Allowed Includes\n\n(none)\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/listings/{listingId}'\n```"
+      description: |-
+        Get a listing from one of your channels by its listing ID
+
+        ###
+
+        ### Allowed Includes
+
+        (none)
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20210222+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/listings/{listingId}?provider=airbnb'
+        ```
       security:
         - OAuth2:
             - 'read:calendar'
+      parameters:
+        - $ref: '#/components/parameters/provider-required'
   /properties:
     get:
       summary: Get properties
@@ -188,7 +222,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: ../../models/property.20191121.yaml
+                      $ref: ../../models/property.20210308.yaml
                   _pagination:
                     $ref: ../../models/pagination.yaml
                 required:
@@ -200,6 +234,7 @@ paths:
                       - id: '123456'
                         name: Room with a view of a tree
                         picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
+                        currency: EUR
                         address:
                           apartment: 37a
                           street: Senefelderplatz
@@ -225,7 +260,20 @@ paths:
                       current_page: 2
                       total_pages: 51
       operationId: get-properties
-      description: "Get all the properties from your account\n\n### Allowed Includes\n\n- listings\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20191201+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/properties'\n```"
+      description: |-
+        Get all the properties from your account
+
+        ### Allowed Includes
+
+        - listings
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20191201+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/properties'
+        ```
       security:
         - OAuth2:
             - 'read:calendar'
@@ -259,7 +307,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: ../../models/property.20191121.yaml
+                    $ref: ../../models/property.20210308.yaml
                 required:
                   - data
               examples:
@@ -269,6 +317,7 @@ paths:
                       id: '123456'
                       name: Room with a view of a tree
                       picture: 'https://cdn2.thecatapi.com/images/d9m.jpg'
+                      currency: EUR
                       address:
                         apartment: 37a
                         street: Senefelderplatz
@@ -291,7 +340,20 @@ paths:
                         rel: property
                         version: '20191121'
       operationId: get-property-by-id
-      description: "Get a property by its unique ID\n\n### Allowed Includes\n\n- `listings`: Include the individual listings associated with that property\n\n### Example\n\n```bash\ncurl -H 'Content-Type: application/vnd.smartbnb.20191201+json' \\\n     -H 'Authorization: Bearer <API TOKEN>' \\\n  'https://api.smartbnb.io/properties/{propertyId}'\n```"
+      description: |-
+        Get a property by its unique ID
+
+        ### Allowed Includes
+
+        - `listings`: Include the individual listings associated with that property
+
+        ### Example
+
+        ```bash
+        curl -H 'Content-Type: application/vnd.smartbnb.20191201+json' \
+             -H 'Authorization: Bearer <API TOKEN>' \
+          'https://api.smartbnb.io/properties/{propertyId}'
+        ```
       parameters:
         - schema:
             type: string
@@ -312,3 +374,26 @@ components:
           tokenUrl: 'https://auth.smartbnb.io/oauth/token'
           scopes:
             'read:calendar': read calendar data
+  parameters:
+    provider-required:
+      name: provider
+      in: query
+      required: true
+      schema:
+        type: string
+        enum:
+          - airbnb
+          - homeaway
+          - booking
+      description: The provider for a listing.
+    provider-optional:
+      name: provider
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - airbnb
+          - homeaway
+          - booking
+      description: The provider for a listing.


### PR DESCRIPTION
Changes to support booking.com:

- Older versions will continue to work as-is.
- In newer versions:
  - `booking` is now a possible provider.
  - Passing a `provider` query string with all requests that contain a listing ID is now required.
    - This is because we cannot distinguish automatically between booking.com and airbnb listing IDs.