### PR TITLE
New version of GET reservations endpoint using properties instead of listings

### DIFF
--- a/paths/calendar/openapi.yaml
+++ b/paths/calendar/openapi.yaml
@@ -108,6 +108,28 @@ paths:
               - guest
           in: query
           name: include
+        - schema:
+            type: array
+          in: query
+          name: properties
+          description: Array of property IDs to query for.
+          required: true
+        - schema:
+            type: string
+            format: date
+            pattern: '\d{4}-\d{2}-\d{2}'
+            example: '2020-02-20'
+          in: query
+          name: start_date
+          description: Find reservations with check-in dates after this day.
+        - schema:
+            type: string
+            format: date
+            pattern: '\d{4}-\d{2}-\d{2}'
+            example: '2020-02-28'
+          in: query
+          name: end_date
+          description: Find reservations with check-in dates before this day.
       security:
         - OAuth2:
             - 'read:calendar'

--- a/paths/calendar/openapi.yaml
+++ b/paths/calendar/openapi.yaml
@@ -97,7 +97,7 @@ paths:
         ### Example
 
         ```bash
-        curl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \
+        curl -H 'Content-Type: application/vnd.smartbnb.20210721+json' \
              -H 'Authorization: Bearer <API TOKEN>' \
           'https://api.smartbnb.io/calendar/reservations?properties[]=123456&properties[]=654321&start_date=2019-08-31&end_date=2019-09-30'
         ```

--- a/paths/calendar/openapi.yaml
+++ b/paths/calendar/openapi.yaml
@@ -81,11 +81,11 @@ paths:
                       total_pages: 1
       operationId: get-reservations
       description: |-
-        Given listings and (optionally) check-in dates, returns a filtered list of reservations.
+        Given properties and (optionally) check-in dates, returns a filtered list of reservations.
 
         ### URL parameters
 
-        - `listings[]`: Array of listing IDs to get reservations for - use as: `?listings[]=123&listings[]=456`. These are the IDs that are available in HomeAway / Airbnb, and you can also get them from the `GET /listings` endpoint.
+        - `properties[]`: Array of property IDs to get reservations for - use as: `?properties[]=123&properties[]=456`. These are the IDs that are available in smartbnb, and you can also get them from the `GET /properties` endpoint.
         - `start_date`: Optional, find reservations with check-in dates after this day. Y-m-d format, defaults to today.
         - `end_date`: Optional, find reservations with check-in dates before this day. Y-m-d format, defaults to `start_date` + 14 days.
 
@@ -99,7 +99,7 @@ paths:
         ```bash
         curl -H 'Content-Type: application/vnd.smartbnb.20190904+json' \
              -H 'Authorization: Bearer <API TOKEN>' \
-          'https://api.smartbnb.io/calendar/reservations?listings[]=123456&listings[]=654321&start_date=2019-08-31&end_date=2019-09-30'
+          'https://api.smartbnb.io/calendar/reservations?properties[]=123456&properties[]=654321&start_date=2019-08-31&end_date=2019-09-30'
         ```
       parameters:
         - schema:
@@ -121,7 +121,7 @@ paths:
         - name: propertyId
           in: path
           required: true
-          description: The ID of the listing to retrieve the calendar for
+          description: The ID of the property to retrieve the calendar for
           schema:
             type: string
         - schema:


### PR DESCRIPTION
Changelog for the new version (20210721):

We no longer support fetching reservations per-listing. While the older versions of this endpoint will continue to work, they will be deprecated (with adequate notice given to consumers of these endpoints). Instead, GET `/reservations` now only functions with Property IDs.

The version sent in `Content-Type` headers should be updated accordingly.